### PR TITLE
RFC: Reorder auth methods to avoid creating unncessary sessions

### DIFF
--- a/app/controllers/auth_controller.py
+++ b/app/controllers/auth_controller.py
@@ -41,9 +41,9 @@ class AuthController(Blueprint):
                 return None
 
     def set_current_user(self):
-        g.user = self._get_user_from_session() or \
-                    self._get_user_from_x_api_auth_token() or \
-                    self._get_user_from_authorization_header()
+        g.user = self._get_user_from_x_api_auth_token() or \
+            self._get_user_from_authorization_header() \
+            self._get_user_from_session()
         if g.user is None and self.require_auth:
             return self.error_response()
 


### PR DESCRIPTION
_This acutally hasn't been tested properly yet, hence the RFC prefix. I might be misunderstanding the problem completely._

Because of `_get_user_from_session()` being executed before
`_get_user_from_x_api_auth_token()` and
`_get_user_from_authorization_header()` there is a session created in
mongodb for **every** API request. As a result, since there is no
automatic session cleanup, a database with just several kilobytes of
useful data may grow to tens of gigabytes over few months.

This change updates the orders of athentication method calls, allowing
to authenticate by `X-Api-Auth-Token` ot `Authorization` headers without
creating an unnesessary session object.